### PR TITLE
Update container workflow to use native multi-arch builds

### DIFF
--- a/.github/workflows/build_container.yml
+++ b/.github/workflows/build_container.yml
@@ -9,35 +9,29 @@ name: Build Container
 
 jobs:
   build_container:
+    uses: docker/github-builder/.github/workflows/build.yml@v1
     permissions:
       contents: read
       packages: write
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - name: Login to GitHub Container Registry
-        # https://github.com/docker/login-action/#github-container-registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
+      id-token: write
+    with:
+      output: image
+      platforms: linux/amd64,linux/arm64
+      push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      distribute: true
+      setup-qemu: false
+      cache: true
+      cache-mode: max
+      context: .
+      file: ./Dockerfile
+      meta-images: ghcr.io/${{ github.repository }}
+      meta-tags: |
+        type=sha,prefix=sha-
+        type=raw,value=latest
+      build-args: |
+        GITHUB_SHA=${{ github.sha }}
+    secrets:
+      registry-auths: |
+        - registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-        # don't log in if we're not going to push!
-        if: ${{ github.ref == 'refs/heads/main' }}
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Build container image
-        id: build_and_export
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-          tags: |
-            ghcr.io/${{ github.repository }}:sha-${{ github.sha }}
-            ghcr.io/${{ github.repository }}:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          build-args: |
-            GITHUB_SHA=${{ github.sha }}


### PR DESCRIPTION
## Summary
- replace the custom QEMU/buildx container job with Docker's reusable `github-builder` workflow
- build `linux/amd64` and `linux/arm64` on native runners and publish a merged multi-arch image on `main`
- preserve existing GHCR tags, build args, caching, and push gating while switching registry auth to `registry-auths`

## Testing
- `mise check`